### PR TITLE
Use node version from .tool-versions in workflows

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -12,6 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
+          cache: yarn
           node-version-file: .tool-versions
       - run: yarn
       - run: yarn lint:eslint
@@ -21,6 +22,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
+          cache: yarn
           node-version-file: .tool-versions
       - run: yarn
       - run: yarn lint:prettier
@@ -30,6 +32,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
+          cache: yarn
           node-version-file: .tool-versions
       - run: yarn
       - run: yarn lint:tsc

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version-file: .tool-versions
       - run: yarn
       - run: yarn lint:eslint
   prettier:
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version-file: .tool-versions
       - run: yarn
       - run: yarn lint:prettier
   tsc:
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version-file: .tool-versions
       - run: yarn
       - run: yarn lint:tsc
   test:
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           cache: yarn
-          node-version: 18.x
+          node-version-file: .tool-versions
       - run: yarn --immutable --immutable-cache
       - run: yarn test:unit
       # uncomment when e2e tests are ok


### PR DESCRIPTION
To bring more consistency to the version of Node.js used in CI and locally. 

Additionally, added a `cache: yarn` input that was missing in some jobs.

---
Follow up of https://github.com/serlo/notification-mail-service/pull/65.