### PR TITLE
Update local MySQL DB configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,5 +10,6 @@ services:
   mysql:
     image: eu.gcr.io/serlo-shared/serlo-mysql-database:latest
     platform: linux/x86_64
+    pull_policy: always
     ports:
       - '3306:3306'

--- a/scripts/mysql/mysql-import-anonymous-data.ts
+++ b/scripts/mysql/mysql-import-anonymous-data.ts
@@ -1,45 +1,88 @@
 import { spawnSync } from 'child_process'
 
-const latestDump = spawnSync(
-  'bash',
-  [
-    '-c',
-    "gsutil ls -l gs://anonymous-data | grep dump | sort -rk 2 | head -n 1 | awk '{ print $3 }'",
-  ],
-  {
+const TMP_DIR = '/tmp'
+
+main()
+
+function main() {
+  const latestDump = getLatestDump()
+  const fileName = getFileName(latestDump)
+  downloadDump(latestDump, fileName)
+
+  const container = getMySQLContainer()
+  if (!container) {
+    info(
+      'MySQL container not found. Please start the database first with "yarn start"!',
+    )
+    return
+  }
+
+  unzipAndCopyToContainer(fileName, container)
+  populateDumpInMySql()
+}
+
+function getLatestDump(): string {
+  const latestDump = spawnSync(
+    'bash',
+    [
+      '-c',
+      "gsutil ls -l gs://anonymous-data | grep dump | sort -rk 2 | head -n 1 | awk '{ print $3 }'",
+    ],
+    {
+      stdio: 'pipe',
+      encoding: 'utf-8',
+    },
+  )
+    .stdout.toString()
+    .trim()
+
+  return latestDump
+}
+
+function getFileName(dumpPath: string): string {
+  const fileName = spawnSync('basename', [dumpPath], {
     stdio: 'pipe',
     encoding: 'utf-8',
-  },
-)
-  .stdout.toString()
-  .trim()
-const fileName = spawnSync('basename', [latestDump], {
-  stdio: 'pipe',
-  encoding: 'utf-8',
-})
-  .stdout.toString()
-  .trim()
+  })
+    .stdout.toString()
+    .trim()
 
-runCmd('gsutil', ['cp', latestDump, `/tmp/${fileName}`])
+  return fileName
+}
 
-const container = spawnSync('docker-compose', ['ps', '-q', 'mysql'], {
-  stdio: 'pipe',
-  encoding: 'utf-8',
-})
-  .stdout.toString()
-  .trim()
+function downloadDump(dumpPath: string, fileName: string) {
+  runCmd('gsutil', ['cp', dumpPath, `${TMP_DIR}/${fileName}`])
+}
 
-runCmd('unzip', ['-o', `/tmp/${fileName}`, '-d', '/tmp'])
-runCmd('docker', ['cp', '/tmp/mysql.sql', `${container}:/tmp/mysql.sql`])
-runCmd('docker', ['cp', '/tmp/user.csv', `${container}:/tmp/user.csv`])
+function getMySQLContainer(): string | null {
+  const container = spawnSync('docker-compose', ['ps', '-q', 'mysql'], {
+    stdio: 'pipe',
+    encoding: 'utf-8',
+  })
+    .stdout.toString()
+    .trim()
 
-info('Start importing MySQL data')
-execCommand(`pv /tmp/mysql.sql | serlo-mysql`)
+  return container || null
+}
 
-info('Start importing anonymized user data')
-execSql(
-  "LOAD DATA LOCAL INFILE '/tmp/user.csv' INTO TABLE user FIELDS TERMINATED BY '\t' LINES TERMINATED BY '\n' IGNORE 1 ROWS;",
-)
+function unzipAndCopyToContainer(fileName: string, container: string) {
+  runCmd('unzip', ['-o', `${TMP_DIR}/${fileName}`, '-d', TMP_DIR])
+  runCmd('docker', [
+    'cp',
+    `${TMP_DIR}/mysql.sql`,
+    `${container}:/tmp/mysql.sql`,
+  ])
+  runCmd('docker', ['cp', `${TMP_DIR}/user.csv`, `${container}:/tmp/user.csv`])
+}
+
+function populateDumpInMySql() {
+  info('Start importing MySQL data')
+  execCommand(`pv ${TMP_DIR}/mysql.sql | serlo-mysql`)
+  info('Start importing anonymized user data')
+  execSql(
+    "LOAD DATA LOCAL INFILE '/tmp/user.csv' INTO TABLE user FIELDS TERMINATED BY '\t' LINES TERMINATED BY '\n' IGNORE 1 ROWS;",
+  )
+}
 
 function execSql(command: string) {
   execCommand(`serlo-mysql --local_infile=1 -e "${command}"`)


### PR DESCRIPTION
Using ./configure_repositories setup-local-mysql ../notification-mail-service.

The main change here is that the latest image of serlo-mysql-database is always pulled, so that the latest version of the image is always used. In this case, the goal is to get the latest changes related to the fixed encoding errors, where the default-character-set is set to `utf8mb4`.

ℹ️ Similar to https://github.com/serlo/db-migrations/pull/124